### PR TITLE
feat: Filter topic tree and data items based on search term

### DIFF
--- a/src/repository/dataItemRepository.ts
+++ b/src/repository/dataItemRepository.ts
@@ -1,10 +1,10 @@
 // @ts-ignore
 import api from '@molgenis/molgenis-api-client'
-import { DataItem } from '@/types/store'
+import { RawDataItem } from '@/types/store'
 
 const refToId = (ref: any): string => ref.id
 
-const toDataItem = (item: any): DataItem => {
+const toDataItem = (item: any): RawDataItem => {
   return {
     id: item.id,
     ageGroups: item.ageGroups,
@@ -19,7 +19,7 @@ const toDataItem = (item: any): DataItem => {
 }
 
 export default {
-  getAll (): Promise<DataItem[]> {
+  getAll (): Promise<RawDataItem[]> {
     return api.get('api/v2/lifelines_dataItems?num=10000').then((response: any) => {
       return response.items.map(toDataItem)
     })

--- a/src/repository/topicRepository.ts
+++ b/src/repository/topicRepository.ts
@@ -7,7 +7,8 @@ const refToId = (ref: any): string => ref.id
 const toTopic = (item: any): Topic => {
   const topic: Topic = {
     id: item.id,
-    label: item.label
+    label: item.label,
+    dataItems: item.dataItems.map(refToId)
   }
 
   if (item.parent) {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -74,22 +74,14 @@ export default {
     const selectedDataItems = new Set(state.selectedDataItems)
     return (item: DataItem): boolean => selectedDataItems.has(item.id)
   },
-  topicDataItems: (state: ApplicationState): DataItem[] => {
-    const topicId = state.selectedOptions.topic
-    if (topicId === undefined) {
-      return []
-    }
-    const selectedTopic = state.lookups.topics[topicId]
+  topicDataItems: (state: ApplicationState, getters: Getters): DataItem[] => {
+    const selectedTopic: VueTopic | undefined = getters.topicList.find(topic => topic.id === state.selectedOptions.topic)
     if (selectedTopic === undefined) {
       return []
     }
-    // TODO: dedupe the search logic
-    const searchTerm = state.selectedOptions.searchTerm.trim().toLowerCase()
-    const matches = (label: string): boolean => label.toLowerCase().indexOf(searchTerm) >= 0
     return selectedTopic.dataItems
         .map((id: string): (DataItem | undefined) => state.allDataItems[id])
         .filter(isDefined as TermGuard<DataItem>)
-        .filter(dataItem => matches(dataItem.label))
   },
   vueDataItems: (state: ApplicationState, getters: Getters): VueDataItem[] =>
     getters.topicDataItems

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -1,0 +1,6 @@
+import { Identifiable, Indexed } from "@/types/store";
+
+export const isDefined = <T> (x: T) => x !== undefined
+export const indexer = <T extends Identifiable>(table: Indexed<T>, current: T): Indexed<T> => ({
+  ...table, [current.id]: current
+})

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -1,4 +1,4 @@
-import { Identifiable, Indexed } from "@/types/store";
+import { Identifiable, Indexed } from '@/types/store'
 
 export const isDefined = <T> (x: T) => x !== undefined
 export const indexer = <T extends Identifiable>(table: Indexed<T>, current: T): Indexed<T> => ({

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,4 +1,4 @@
-import { ApplicationState, CategoricalFacet, DataItem, Topic } from '@/types/store'
+import { ApplicationState, CategoricalFacet, RawDataItem, Topic } from '@/types/store'
 
 const toggle = (list: string[], item: string): void => {
   if (list.includes(item)) {
@@ -28,7 +28,7 @@ export default {
   toggleCollectionPointOption (state: ApplicationState, toggledOptionId: string) {
     toggle(state.selectedOptions.collectionPoint, toggledOptionId)
   },
-  setDataItems (state: ApplicationState, dataItems: DataItem[]) {
+  setDataItems (state: ApplicationState, dataItems: RawDataItem[]) {
     state.dataItems = dataItems
   },
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,8 +1,9 @@
-import ApplicationState from '@/types/store'
+import ApplicationState, { CategoricalFacetOption, Indexed, Lookups, Topic } from '@/types/store'
 
 const state: ApplicationState = {
-  dataItems: [],
+  allDataItems: {},
   topics: [],
+  topicTree: [],
   categoricalFacets: {
     collectionPoint: { id: 'collectionPoint', label: '', options: [] },
     ageGroup:  { id: 'ageGroup', label: '', options: [] },
@@ -17,6 +18,13 @@ const state: ApplicationState = {
     collectionPoint: [],
     searchTerm: ''
   },
+  lookups: {
+    collectionPoint: {},
+    ageGroup: {},
+    sexGroup: {},
+    subCohorts: {},
+    topics: {}
+  } as Lookups,
   openTopics: [],
   selectedDataItems: []
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -28,7 +28,7 @@ export interface Lookups {
   topics: Indexed<Topic>
 }
 
-export interface DataItem extends Identifiable {
+export interface RawDataItem extends Identifiable {
   ageGroups: string[]
   sexGroups: string[]
   subCohorts: string[]
@@ -36,6 +36,16 @@ export interface DataItem extends Identifiable {
   topic: string
   label: string
   ordinalPosition: number
+  description: string
+}
+
+export interface DataItem extends Identifiable {
+  ageGroups: CategoricalFacetOption[]
+  sexGroups: CategoricalFacetOption[]
+  subCohorts: CategoricalFacetOption[]
+  collectionPoints: CategoricalFacetOption[]
+  topic: Topic
+  label: string
   description: string
 }
 
@@ -48,18 +58,20 @@ export interface TopicNode extends Topic {
   children: TopicNode[]
 }
 
+export type SelectedOptions = {
+  ageGroup: string[]
+  sexGroup: string[]
+  subCohorts: string[]
+  collectionPoint: string[]
+  topic?: string
+  searchTerm: string
+}
+
 export interface ApplicationState {
-  dataItems: DataItem[]
+  dataItems: RawDataItem[]
   topics: Topic[]
   categoricalFacets: CategoricalFacets
-  selectedOptions: {
-    ageGroup: string[];
-    sexGroup: string[];
-    subCohorts: string[];
-    collectionPoint: string[];
-    topic?: string
-    searchTerm: string;
-  }
+  selectedOptions: SelectedOptions
   selectedDataItems: string[]
   openTopics: string[]
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -69,12 +69,16 @@ export type SelectedOptions = {
 }
 
 export interface ApplicationState {
-  dataItems: RawDataItem[]
+  allDataItems: Indexed<DataItem>
   topics: Topic[]
+  topicTree: TopicNode[]
   categoricalFacets: CategoricalFacets
   selectedOptions: SelectedOptions
   selectedDataItems: string[]
   openTopics: string[]
+  lookups: Lookups
 }
 
 export default ApplicationState
+
+export type TermGuard<T> = (x: T | undefined) => x is T

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -52,6 +52,7 @@ export interface DataItem extends Identifiable {
 export interface Topic extends Identifiable {
   label: string
   parentTopicId?: string
+  dataItems: string[]
 }
 
 export interface TopicNode extends Topic {

--- a/src/views/LifelinesWebshop.vue
+++ b/src/views/LifelinesWebshop.vue
@@ -67,7 +67,7 @@
 
   export default Vue.extend({
     name: 'LifelinesWebshop',
-    components: {Facet, DataItems, TopicTree, SearchBar},
+    components: { Facet, DataItems, TopicTree, SearchBar },
     props: {
       msg: String
     },


### PR DESCRIPTION
## N.B. You need to add a onetomany dataItems attribute to the topic entity!
(I've added it on molgenis09)

Updates the enabled/disabled criteria to use && instead of ||, you must select one of each attribute before you can select the data item (except for age groups cause those do not work yet?)