### PR TITLE
Improve performance

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -4,39 +4,28 @@ import dataItemRepository from '@/repository/dataItemRepository'
 
 export default {
 
-  getDataItems ({ commit }: any) {
-    return dataItemRepository.getAll().then((dataItems) => {
-      commit('setDataItems', dataItems)
-    }).catch()
-  },
+  getDataFromBackend ({ commit }: any) {
 
-  getTopics ({ commit }: any) {
-    topicRepository.getAll().then((topics) => {
-      commit('setTopics', topics)
-    }).catch()
-  },
-
-  getAgeGroups ({ commit }: any) {
     categoricalFacetRepository.getAgeGroups().then((ageGroups) => {
       commit('setAgeGroups', ageGroups)
     }).catch()
-  },
 
-  getSexGroups ({ commit }: any) {
     categoricalFacetRepository.getSexGroups().then((sexGroups) => {
       commit('setSexGroups', sexGroups)
     }).catch()
-  },
 
-  getSubCohorts ({ commit }: any) {
     categoricalFacetRepository.getSubCohorts().then((subCohorts) => {
       commit('setSubCohorts', subCohorts)
     }).catch()
-  },
 
-  getCollectionPoints ({ commit }: any) {
     categoricalFacetRepository.getCollectionPoints().then((collectionPoints) => {
       commit('setCollectionPoints', collectionPoints)
     }).catch()
+
+    Promise.all([dataItemRepository.getAll(), topicRepository.getAll()]).then((results) => {
+      commit('setDataItems', results[0])
+      commit('setTopics', results[1])
+    }).catch()
+
   }
 }

--- a/src/views/LifelinesWebshop.vue
+++ b/src/views/LifelinesWebshop.vue
@@ -95,28 +95,14 @@
       msg: String
     },
     methods: {
-      ...mapActions([
-        'getDataItems',
-        'getTopics',
-        'getAgeGroups',
-        'getSexGroups',
-        'getSubCohorts',
-        'getCollectionPoints'
-      ]),
+      ...mapActions(['getDataFromBackend']),
       ...mapMutations(['reset'])
     },
     computed: {
       ...mapGetters(['vueDataItems', 'selectionCount'])
     },
     mounted () {
-      this.getAgeGroups()
-      this.getSexGroups()
-      this.getSubCohorts()
-      this.getCollectionPoints()
-
-      this.getDataItems().then(() => {
-        this.getTopics()
-      })
+      this.getDataFromBackend()
 
     }
   })


### PR DESCRIPTION
Execute fetch of dataItems and Topics in parallel to improve performance.

Wait for both items and topics to be fetched before building tree